### PR TITLE
Add support for nested requirements

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+based_on_style = pep8
+column_limit = 99

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = {posargs:py.test -v -s tests}
 
 
 [testenv:flakes]
-commands = 
+commands =
     py.test --pep8 --doctest-modules toxbat
 
 


### PR DESCRIPTION
This patch implements the support for nested requirements.

The use case for this is when a project contains a requirements.txt
file pointing to another requirements file (i.e.:
production-requirements.txt) which also points to other requirement
files.

The patch achieves this by compiling the list of all the requirements,
hashing it, and comparing this hash to the hash of the previous tox run
(if any).