### PR TITLE
Fix file names of files with previous hashes

### DIFF
--- a/toxbat/requirements.py
+++ b/toxbat/requirements.py
@@ -61,7 +61,7 @@ def are_requirements_changed(config):
 
     def build_fpath_for_previous_version(fname):
         tox_dir = config.config.toxworkdir.strpath
-        fname = '{0}.{0}.previous'.format(fname.replace('/', '-'), config.envname)
+        fname = '{0}.{1}.previous'.format(fname.replace('/', '-'), config.envname)
         return os.path.join(tox_dir, fname)
 
     requirement_files = map(parse_requirements_fname, deps)


### PR DESCRIPTION
`tox-battery` stores a hash per requirements file and per environment to
check for changes. There was a subtle bug, which would result in the
environment not to be included in the file name, resulting in the same
file name for multiple environments, which broke the functionality of
`tox-battery` when using it with multiple environments which used
requirement files with the same name. This commit fixes that.