### PR TITLE
Fix #14 support pip 10 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pip-log.txt
 
 # Sphinx
 docs/_build
+.pytest_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - python: pypy
       env: TOXENV=pypy
 install:
+  - pip install -U pip
   - pip install tox
 script:
   - tox

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description='Additional functionality for tox',
     long_description=content_of("README.rst"),
     license='http://opensource.org/licenses/MIT',
-    version='0.5',
+    version='0.5.1',
     author='Volodymyr Vitvitskyi',
     author_email='contact.volodymyr@gmail.com',
     url='https://github.com/signalpillar/tox-battery',

--- a/toxbat/requirements.py
+++ b/toxbat/requirements.py
@@ -35,8 +35,15 @@ import hashlib
 import os
 
 # 3rd-party
-from pip.download import PipSession
-from pip.req import parse_requirements
+try:
+    from pip.download import PipSession
+    from pip.req import parse_requirements
+except ImportError:
+    # It is quick hack to support pip 10 that has changed its internal
+    # structure of the modules.
+    from pip._internal.download import PipSession
+    from pip._internal.req.req_file import parse_requirements
+
 from tox import hookimpl
 
 


### PR DESCRIPTION
Problem
-------
As expected when using the internal implementation on major changes it breaks.
With release of pip 10 functionality to parse the requirements files is moved to
a different place so it can't be imported any more.

Solution
--------
Fallback to a new location if an old one cannot be found.

Testing
-------
All the tests pass