### PR TITLE
[pip>=20] add support for a new version of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install pip==19.1.1
   - pip install tox
 script:
-  - tox -vvv
+  - tox -v
 sudo: false
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,14 @@ matrix:
     - python: 3.7
     - python: 3.8
     - python: pypy
+env:
+  - TOX_PIP_VERSION=20.0.2
+  - TOX_PIP_VERSION=19.3.1
+  - TOX_PIP_VERSION=18.1
+  - TOX_PIP_VERSION=10.0.1
 install:
   - pip install pip==19.1.1
+  - pip install tox-pip-version
   - pip install tox
 script:
   - tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install pip==19.1.1
   - pip install tox
 script:
-  - tox
+  - tox -vvv
 sudo: false
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,12 @@ language: python
 matrix:
   fast_finish: true
   include:
-    - python: 2.6
-      env: TOXENV=py26
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
     - python: pypy
       env: TOXENV=pypy
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,9 @@ matrix:
   fast_finish: true
   include:
     - python: 3.6
-      env: TOXENV=py36
     - python: 3.7
-      env: TOXENV=py37
     - python: 3.8
-      env: TOXENV=py38
     - python: pypy
-      env: TOXENV=pypy
 install:
   - pip install -U pip
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     - python: 3.8
     - python: pypy
 install:
-  - pip install -U pip
+  - pip install pip==19.1.1
   - pip install tox
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
-matrix:
-  fast_finish: true
-  include:
-    - python: 3.6
-    - python: 3.7
-    - python: 3.8
-    - python: pypy
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+  - pypy
 env:
   - TOX_PIP_VERSION=20.0.2
   - TOX_PIP_VERSION=19.3.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description='Additional functionality for tox',
     long_description=content_of("README.rst"),
     license='http://opensource.org/licenses/MIT',
-    version='0.5.1',
+    version='0.5.2',
     author='Volodymyr Vitvitskyi',
     author_email='contact.volodymyr@gmail.com',
     url='https://github.com/signalpillar/tox-battery',

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -64,6 +64,7 @@ def test_venv_reused_for_different_testenvironments(in_project, cwd):
         deps =
             -rrequirements-test.txt
         commands =
+            pip --version
             flake8,test: flake8 --version
             unit,test: pytest --version
     '''))
@@ -76,6 +77,7 @@ def test_venv_reused_for_different_testenvironments(in_project, cwd):
 
     # exercise
     _, stdout, stderr = run('tox', cwd, capture_output=True)
+    print(stdout)
 
     # verify
     assert 'unit recreate:' not in stdout,\

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ skip_missing_interpreters = true
 usedevelop = True
 
 deps =
-    pip20:-- --ignore-installed pip==20.0.2
-    pip19:-- --ignore-installed pip==19.3.1
-    pip18:-- --ignore-installed pip==18.1
-    pip10:-- --ignore-installed pip==10.0.1
+    pip20: -- --ignore-installed pip==20.0.2
+    pip19: -- --ignore-installed pip==19.3.1
+    pip18: -- --ignore-installed pip==18.1
+    pip10: -- --ignore-installed pip==10.0.1
     tox
     pytest
     pytest-pep8

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     # pip18: pip==18.1
     # pip10: pip==10.0.1
     tox
+    tox-pip-version
     pytest
     pytest-pep8
     pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
-envlist = flakes,py26,py27,py33,py34,py35,py36,pypy
+envlist = flakes,py{36,37,38}-pip{20,19,18,10},pypy
 
 [testenv]
 usedevelop = True
 
 deps =
+    pip20: pip>=20.0.0
+    pip19: pip>=19,<20
+    pip18: pip>=18,<19
+    pip10: pip>=10,<11
     tox
     pytest
     pytest-pep8

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ skip_missing_interpreters = true
 usedevelop = True
 
 deps =
-    pip20: --ignore-installed pip==20.0.2
-    pip19: --ignore-installed pip==19.3.1
-    pip18: --ignore-installed pip==18.1
-    pip10: --ignore-installed pip==10.0.1
+    pip20:-- --ignore-installed pip==20.0.2
+    pip19:-- --ignore-installed pip==19.3.1
+    pip18:-- --ignore-installed pip==18.1
+    pip10:-- --ignore-installed pip==10.0.1
     tox
     pytest
     pytest-pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flakes,py{36,37,38}-pip{20,19,18,10},pypy
+envlist = flakes,py{36,37,38},pypy
 skip_missing_interpreters = true
 
 [testenv]
@@ -7,10 +7,6 @@ usedevelop = True
 install_command=python -m pip install --ignore-installed {opts} {packages}
 
 deps =
-    # pip20: pip==20.0.2
-    # pip19: pip==19.3.1
-    # pip18: pip==18.1
-    # pip10: pip==10.0.1
     tox
     tox-pip-version
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,7 @@ commands = {posargs:py.test -v -s tests}
 
 [testenv:flakes]
 commands =
-    py.test
-      --durations=5
-      -v
-      --pep8
-      --doctest-modules
-      toxbat
+    py.test --durations=5 -v --pep8 --doctest-modules toxbat
 
 
 [pytest]

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,13 @@ skip_missing_interpreters = true
 
 [testenv]
 usedevelop = True
+install_command=python -m pip install --ignore-installed {opts} {packages}
 
 deps =
-    pip20: -- --ignore-installed pip==20.0.2
-    pip19: -- --ignore-installed pip==19.3.1
-    pip18: -- --ignore-installed pip==18.1
-    pip10: -- --ignore-installed pip==10.0.1
+    pip20: pip==20.0.2
+    pip19: pip==19.3.1
+    pip18: pip==18.1
+    pip10: pip==10.0.1
     tox
     pytest
     pytest-pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = flakes,py{36,37,38}-pip{20,19,18,10},pypy
+skip_missing_interpreters = true
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@ usedevelop = True
 install_command=python -m pip install --ignore-installed {opts} {packages}
 
 deps =
-    pip20: pip==20.0.2
-    pip19: pip==19.3.1
-    pip18: pip==18.1
-    pip10: pip==10.0.1
+    # pip20: pip==20.0.2
+    # pip19: pip==19.3.1
+    # pip18: pip==18.1
+    # pip10: pip==10.0.1
     tox
     pytest
     pytest-pep8

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@ skip_missing_interpreters = true
 usedevelop = True
 
 deps =
-    pip20: pip>=20.0.0
-    pip19: pip>=19,<20
-    pip18: pip>=18,<19
-    pip10: pip>=10,<11
+    pip20: --ignore-installed pip==20.0.2
+    pip19: --ignore-installed pip==19.3.1
+    pip18: --ignore-installed pip==18.1
+    pip10: --ignore-installed pip==10.0.1
     tox
     pytest
     pytest-pep8

--- a/toxbat/requirements.py
+++ b/toxbat/requirements.py
@@ -30,19 +30,23 @@ Name of the version file is composed from 2 parts:
     creation procedure.
 """
 
-# std
 import hashlib
 import os
 
-# 3rd-party
 try:
-    from pip.download import PipSession
-    from pip.req import parse_requirements
-except ImportError:
-    # It is quick hack to support pip 10 that has changed its internal
-    # structure of the modules.
-    from pip._internal.download import PipSession
+    # pip >= 20
+    from pip._internal.network.session import PipSession
     from pip._internal.req.req_file import parse_requirements
+except ImportError:
+    try:
+        # pip < 10
+        from pip.download import PipSession
+        from pip.req import parse_requirements
+    except ImportError:
+        # It is quick hack to support pip 10 that has changed its internal
+        # structure of the modules.
+        from pip._internal.download import PipSession
+        from pip._internal.req.req_file import parse_requirements
 
 from tox import hookimpl
 


### PR DESCRIPTION
Note: We shouldn't really depend on internals of the library as they don't
provide any support for those. Suggested solution is to call `pip freeze`
command to get the dependencies parsed.