### PR TITLE
Handle None filenames when processing nested files

### DIFF
--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -43,6 +43,11 @@ class TestAllNestedFiles:
         files = ["f1.txt", "f2.txt"]
         assert files == list(requirements.all_nested_req_files(files))
 
+    def test_none_in_filelist_doesnot_cause_error(self, tmpdir):
+        """tox-battery doesn't complain if file doesn't exist."""
+        files = [None, "f2.txt"]
+        assert files == list(requirements.all_nested_req_files(files))
+
     @pytest.mark.parametrize("pipoption", ["-c", "-r"])
     def test_existing_file_is_nested(self, tmpdir, pipoption):
         """tox-battery supports nested requirement files."""

--- a/toxbat/requirements.py
+++ b/toxbat/requirements.py
@@ -68,7 +68,7 @@ def all_nested_req_files(requirement_files):
     for reqfile in requirement_files:
         yield reqfile
 
-        if os.path.isfile(reqfile):
+        if reqfile and os.path.isfile(reqfile):
             parent_dir = os.path.dirname(reqfile)
             with open(reqfile) as f:
                 yield from all_nested_req_files(


### PR DESCRIPTION
Because the tox deps list is mapped through the
`parse_requirements_fname` function.  Some values in the initial list
can be none.  Skip over those instead of throwing an error.
