### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     entry_points={"tox": ["toxbat-requirements = toxbat.requirements"]},
     install_requires=["tox"],
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This patch adds `python_requires` to `setup.py` so that pip won't install this on Python 2.7, 3.5, or other unsupported versions.